### PR TITLE
add ceph rpm install in RHEL & CentOS

### DIFF
--- a/doc/start/quick-start-preflight.rst
+++ b/doc/start/quick-start-preflight.rst
@@ -85,9 +85,9 @@ For CentOS 7, perform the following steps:
 	gpgkey=https://download.ceph.com/keys/release.asc
 
 
-#. Update your repository and install ``ceph-deploy``::
+#. Update your repository and install ``ceph-deploy`` & ``ceph``::
 
-	sudo yum update && sudo yum install ceph-deploy
+	sudo yum update && sudo yum install ceph ceph-deploy
 
 
 .. note:: You can also use the EU mirror eu.ceph.com for downloading your packages.


### PR DESCRIPTION
I followed installation guide I succeeded set up 3 node cluster for testing. But when I run ``ceph-deploy osd prepare`` command, I got error:
[ceph_deploy][ERROR ] ExecutableNotFound: Could not locate executable 'ceph-disk' make sure it is installed and available on host1

Which was caused by ceph not installed on hosts.

BTW, I didn't test on Ubuntu, so I don't know whether the same problem exists. But I think it should be the same situation on Ubuntu.